### PR TITLE
Fix the mention's span's class

### DIFF
--- a/nova.css
+++ b/nova.css
@@ -263,13 +263,13 @@ div.channel.channel-text.selected {
 }
 
 /*Mention*/
-.markup .highlight {
+.markup .mention {
     background-color: rgba(255,255,255,.1) !important;
     color: #ddd;
     border-radius: 10%;
 }
 
-.markup .highlight:hover {
+.markup .mention:hover {
     background-color: rgba(255,255,255,.2) !important;
     color: #ddd;
     border-radius: 10%;


### PR DESCRIPTION
The mention's span's class changed from .highlight to .mention in today's update.