### PR TITLE
Fixes background not showing up

### DIFF
--- a/nova.css
+++ b/nova.css
@@ -7,7 +7,7 @@
  */
 
 /* Background */
-.app {
+.layer {
     background-image: url(https://i.imgur.com/h0YyOD7.png);
     background-size: cover;
 }


### PR DESCRIPTION
The newest version of Discord changes on which div the background color is applied. This change overwrites Discord's background color with the theme's background image.